### PR TITLE
chore(release): add notes generator; update CHANGELOG; housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ runtime.cfg.local
 .DS_Store
 
 .DS_Store
+RELEASE_NOTES-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# v2025.08.01 — Release Notes
+
+**Range:** `d91e4b25a10ad4afc1f83e8767c36838d0c1d078..v2025.08.01`
+
+## Highlights
+- chore: add PR template
+- Added a pre-merge hook.
+- Removed main.sh and updated bats tests.
+- Resolved conflict test_coverage_summary_real.bats
+- Updated test_coverage_summary_real.bats for merging
+- Updating resolve_project_root
+- Removed old policy and back up files.Updated snapshot/spec file.
+- Savepoint before merge
+- ./tools/gen_readme.rf.rf.sh is now working and generating correct number of unit tests.
+- Updated root/strucutre.spec
+
+## Changes by type

--- a/RELEASE_NOTES-v2025.08.01.md
+++ b/RELEASE_NOTES-v2025.08.01.md
@@ -1,0 +1,17 @@
+# v2025.08.01 — Release Notes
+
+**Range:** `d91e4b25a10ad4afc1f83e8767c36838d0c1d078..v2025.08.01`
+
+## Highlights
+- chore: add PR template
+- Added a pre-merge hook.
+- Removed main.sh and updated bats tests.
+- Resolved conflict test_coverage_summary_real.bats
+- Updated test_coverage_summary_real.bats for merging
+- Updating resolve_project_root
+- Removed old policy and back up files.Updated snapshot/spec file.
+- Savepoint before merge
+- ./tools/gen_readme.rf.rf.sh is now working and generating correct number of unit tests.
+- Updated root/strucutre.spec
+
+## Changes by type

--- a/structure.spec
+++ b/structure.spec
@@ -9,6 +9,7 @@ dir: ./modules/unit_testing/
 dir: ./modules/unit_testing/environment/
 dir: ./modules/unit_testing/experimentation/
 dir: ./modules/unit_testing/fsm/
+dir: ./root-test/
 dir: ./system/
 dir: ./system-test/
 dir: ./system-test/features/
@@ -29,9 +30,12 @@ dir: ./tools/git-hooks/
 dir: ./tools/providers/
 dir: ./tools/providers/localfs/
 dir: ./tools/providers/terraform/
+dir: ./tools/release/
 dir: ./tools/structure/
+file: ./.github/pull_request_template.md
 file: ./.gitignore
 file: ./.structure.ignore
+file: ./CHANGELOG.md
 file: ./Makefile
 file: ./README.generated.md
 file: ./README.md
@@ -115,6 +119,7 @@ file: ./tools/git-hooks/pre-merge-check.sh
 file: ./tools/git-hooks/pre-push
 file: ./tools/install-hooks.sh
 file: ./tools/pre-git-switch.sh
+file: ./tools/release/gen_notes.sh
 file: ./tools/scan_duplicate_targets.sh
 file: ./tools/setup.sh
 file: ./tools/structure/structure_snapshot_gen.sh

--- a/tools/release/gen_notes.sh
+++ b/tools/release/gen_notes.sh
@@ -1,0 +1,45 @@
+TAG="v2025.08.01"
+# Previous tag (fallback to repo root if none)
+PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || git rev-list --max-parents=0 HEAD | tail -1)
+
+OUT="RELEASE_NOTES-${TAG}.md"
+
+{
+  echo "# ${TAG} — Release Notes"
+  echo
+  echo "**Range:** \`${PREV}..${TAG}\`"
+  echo
+  echo "## Highlights"
+  echo "## Highlights"
+git log --no-merges --pretty='- %s' "$PREV..$TAG" | head -n 12 || echo "_none_"
+  echo
+  echo "## Changes by type"
+  for T in feat fix perf refactor docs test chore; do
+    echo "### ${T^}"
+    git log --no-merges --pretty='* %h %s (%an)' "${PREV}..${TAG}" \
+      | grep -i "^* .*${T}:" || echo "_none_"
+    echo
+  done
+  echo "### Other"
+  git log --no-merges --pretty='* %h %s (%an)' "${PREV}..${TAG}" \
+    | grep -viE ' (feat|fix|perf|refactor|docs|test|chore):' || echo "_none_"
+  echo
+  echo "## Diffstat"
+  git diff --stat "${PREV}..${TAG}"
+  echo
+  echo "## Areas touched (top-level dirs)"
+  git diff --name-only "${PREV}..${TAG}" \
+    | awk -F/ 'NF==1{print "(root)"; next}{print $1}' \
+    | sort | uniq -c | sort -nr
+  echo
+  echo "## Churn by folder (adds/removes)"
+  git diff --numstat "${PREV}..${TAG}" \
+    | awk -F'\t' '{split($3,a,"/"); d=(a[1]?a[1]:"(root)"); add[d]+=$1; del[d]+=$2} \
+END{for (d in add) printf "%-20s +%6d  -%6d  (±%6d)\n", d, add[d], del[d], add[d]+del[d]}' \
+    | sort -k4,4nr
+  echo
+  echo "## Contributors"
+  git shortlog -sne "${PREV}..${TAG}"
+} > "$OUT"
+
+echo "Wrote $OUT"


### PR DESCRIPTION
## Summary
Explain what this PR does and why now.

## Changes
- Feature(s): gen_notes.sh to generate RELEASE_NOTES<tag>
- Fix(es):
- Refactor/Chore/Docs: Added on pre-merge template. Generated CHANGELOG.md, RELEASE_NOTES-v2025.08.01.md
and updated structure.spec

## Scope / Impact
- Areas touched (dirs/files):
   4 (root)
   1 tools

M       .gitignore
A       CHANGELOG.md
A       RELEASE_NOTES-v2025.08.01.md
M       structure.spec
A       tools/release/gen_notes.sh


.gitignore           +     1  -     0  (±     1)
CHANGELOG.md         +    17  -     0  (±    17)
RELEASE_NOTES-v2025.08.01.md +    17  -     0  (±    17)
structure.spec       +     5  -     0  (±     5)
tools                +    45  -     0  (±    45)



 
## Release Notes
- [ X] User-facing change? Note it here.
      CHANGELOG.md
       RELEASE_NOTES-v2025.08.01.md

## Checklist
- [ X] Branch up to date with `main`
- [ ] Tests added/updated
- [ ] Lint/format passes
- [X ] Reviewed by: abe
